### PR TITLE
Debug sentry and connection refused errors

### DIFF
--- a/server/data/users.json
+++ b/server/data/users.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": 1,
+    "username": "admin",
+    "password": "$2a$10$5dQJXxYm9EFgQxDZ.IYcQuK9UqV8QKrHvKGBhEF9mGHxOxXcLpJZu",
+    "email": "admin@fastboot.com",
+    "role": "admin",
+    "isActive": true,
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  }
+]


### PR DESCRIPTION
Add default admin user to `server/data/users.json` to enable server login.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c24245f-1c71-42ce-ab2c-c9930470d8cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c24245f-1c71-42ce-ab2c-c9930470d8cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

